### PR TITLE
Add basic test coverage with PHPUnit

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,9 @@
     "php": "^8.0",
     "ext-pdo": "*"
   },
+  "require-dev": {
+    "phpunit/phpunit": "^11.0"
+  },
   "suggest": {
     "ext-pdo_mysql": "For MySQL/MariaDB connections",
     "ext-pdo_pgsql": "For PostgreSQL connections",

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit bootstrap="vendor/autoload.php" colors="true">
+    <testsuites>
+        <testsuite name="PdoDb Test Suite">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/src/PdoDb.php
+++ b/src/PdoDb.php
@@ -1357,11 +1357,11 @@ class PdoDb
      * 
      * @param string $tableName Table name
      * @param array $multiInsertData Multi-dimensional array of data
-     * @param array $dataKeys Column names
+     * @param array|null $dataKeys Column names
      * @return bool|array Insert IDs or false
      * @throws Exception
      */
-    public function insertMulti($tableName, array $multiInsertData, array $dataKeys = null)
+    public function insertMulti($tableName, array $multiInsertData, ?array $dataKeys = null)
     {
         $autoCommit = ($this->_transactionLevel === 0);
         $ids = array();

--- a/tests/PdoDbTest.php
+++ b/tests/PdoDbTest.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace Lakshanjs\PdoDb\Tests;
+
+use Lakshanjs\PdoDb\PdoDb;
+use PHPUnit\Framework\TestCase;
+
+class PdoDbTest extends TestCase
+{
+    private PdoDb $db;
+
+    protected function setUp(): void
+    {
+        $config = [
+            'driver' => 'sqlite',
+            'db' => ':memory:',
+        ];
+
+        $this->db = new PdoDb($config);
+        $create = 'CREATE TABLE users (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            email TEXT,
+            login TEXT,
+            status TEXT,
+            views INTEGER DEFAULT 0
+        )';
+        $this->db->rawQuery($create);
+    }
+
+    public function testInsertAndGet(): void
+    {
+        $id = $this->db->insert('users', [
+            'email' => 'a@example.com',
+            'login' => 'a',
+            'status' => 'active'
+        ]);
+        $this->assertNotFalse($id);
+
+        $user = $this->db->where('id', $id)->getOne('users');
+        $this->assertSame('a@example.com', $user['email']);
+    }
+
+    public function testUpdateWithIncrement(): void
+    {
+        $id = $this->db->insert('users', [
+            'email' => 'b@example.com',
+            'login' => 'b',
+            'status' => 'active',
+            'views' => 1
+        ]);
+        $this->db->where('id', $id)->update('users', ['views' => $this->db->inc()]);
+
+        $views = $this->db->where('id', $id)->getValue('users', 'views');
+        $this->assertSame(2, (int)$views);
+    }
+
+    public function testDelete(): void
+    {
+        $id = $this->db->insert('users', [
+            'email' => 'c@example.com',
+            'login' => 'c',
+            'status' => 'inactive'
+        ]);
+        $deleted = $this->db->where('id', $id)->delete('users');
+        $this->assertTrue((bool)$deleted);
+
+        $count = $this->db->getValue('users', 'COUNT(*)');
+        $this->assertSame(0, (int)$count);
+    }
+
+    public function testTransactionRollback(): void
+    {
+        $this->db->startTransaction();
+        $this->db->insert('users', [
+            'email' => 'd@example.com',
+            'login' => 'd'
+        ]);
+        $this->db->rollback();
+
+        $count = $this->db->getValue('users', 'COUNT(*)');
+        $this->assertSame(0, (int)$count);
+    }
+}


### PR DESCRIPTION
## Summary
- add PHPUnit configuration and dev dependency
- cover PdoDb with basic CRUD and transaction tests using SQLite

## Testing
- `composer lint`
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_68a0a31160608324aff79321f547779d